### PR TITLE
Clarify init method in derived classes

### DIFF
--- a/Jupyter-Notebooks/03_Introduction_Classes.ipynb
+++ b/Jupyter-Notebooks/03_Introduction_Classes.ipynb
@@ -676,6 +676,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3ce83c35",
+   "metadata": {},
+   "source": [
+    "Note: A derived class does not need to define a new __init__ dunder method if there is no need to change the __init__ method from the base class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3114fa8a",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Mention that there is no need for a new __init__ method in derived classes, unless one wishes to change it w.r.t. the one in the base class.